### PR TITLE
Bugfix for 10.1/10.2 - fjerner boolsk tolkning av tekstfelt

### DIFF
--- a/templates/pale-2/pale-2.hbs
+++ b/templates/pale-2/pale-2.hbs
@@ -589,13 +589,10 @@
     <tbody>
     <tr>
         <td><h4>10.1 Er det noe i legeerklæringen som pasienten ikke bør få vite av medisinske grunner?</h4></td>
-        {{#if legeerklaering.pasientenBurdeIkkeVite}}JA{{/if}}
+        {{#if legeerklaering.pasientenBurdeIkkeVite}}
+            {{ legeerklaering.pasientenBurdeIkkeVite }}
+        {{/if}}
         {{#unless legeerklaering.pasientenBurdeIkkeVite}}NEI{{/unless}}
-    </tr>
-    <tr>
-        <td><h4>10.2 Hvis Ja, oppgi hva pasienten ikke bør vite</h4></td>
-        {{ legeerklaering.pasientenBurdeIkkeVite }}
-        {{#unless legeerklaering.kontakt.onskesKopiAvVedtak}}NEI{{/unless}}
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Denne feilen tolket ev. innhold i pasientenBurdeIkkeVite som en boolsk verdi. Dette førte til at svaret på spørsmålet "10.1 Er det noe i legeerklæringen som pasienten ikke bør få vite av medisinske grunner?" ble JA, til tross for at legen gjerne hadde skrevet inn "Nei." i feltet.

Fjerner boolsk tolkning og putter inn innholdet hvis utfylt, ellers NEI.